### PR TITLE
Add better error handling

### DIFF
--- a/mandrill_test.go
+++ b/mandrill_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -80,6 +81,15 @@ func Test_MessagesSendTemplate_Fail(t *testing.T) {
 		Message: "No subaccount exists with the id 'customer-123'",
 	}
 	expect(t, reflect.DeepEqual(correctResponse, err), true)
+}
+
+func Test_MessagesSendTemplate_Unexpected(t *testing.T) {
+	server, m := testTools(415, `{}`)
+	defer server.Close()
+	responses, err := m.MessagesSendTemplate(&Message{}, "cheese", map[string]string{"name": "bob"})
+
+	expect(t, len(responses), 0)
+	expect(t, strings.Contains(err.Error(), "415"), true)
 }
 
 // MessagesSend //////////


### PR DESCRIPTION
![#1](https://media2.giphy.com/media/xThtavauz3DKybut8s/giphy.gif?cid=3640f6095c05d86f316f6c51779ee75e)

We were getting errors with empty message strings. Upon digging in, we realized there's a missed case where there isn't a meaningful response from Mandrill. However, we can still propagate the information about the http error we encountered